### PR TITLE
Fix for handling single line config files, connected with line ending…

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -45,7 +45,7 @@ do
     echo "# Configuration for $UPSTREAM" >> $CONFIG_FILE
 
     # Read the upstream file line by line
-    while read LINE || [ -n "$LINE" ];
+    while read -r LINE || [ -n "$LINE" ];
     do
         # Skip line if it is a comment
         if [[ ${LINE:0:1} == '#' ]]; then

--- a/generate.sh
+++ b/generate.sh
@@ -45,7 +45,7 @@ do
     echo "# Configuration for $UPSTREAM" >> $CONFIG_FILE
 
     # Read the upstream file line by line
-    while read -r LINE;
+    while read LINE || [ -n "$LINE" ];
     do
         # Skip line if it is a comment
         if [[ ${LINE:0:1} == '#' ]]; then


### PR DESCRIPTION

It was observed that when attempting to process single line configs, for example hirez.txt, the script would not create local-data entry correctly.   The section would be commented, but there would be no entry written by the while loop.

